### PR TITLE
Add CancelSale command and related processing logic

### DIFF
--- a/template/backend/src/Ambev.DeveloperEvaluation.Application/Sales/CancelSale/CancelSaleCommand.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.Application/Sales/CancelSale/CancelSaleCommand.cs
@@ -1,0 +1,30 @@
+using Ambev.DeveloperEvaluation.Common.Validation;
+using MediatR;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.CancelSale;
+
+/// <summary>
+/// Command for cancelling a sale.
+/// </summary>
+public class CancelSaleCommand : IRequest<CancelSaleResult>
+{
+    /// <summary>
+    /// Gets or sets the sale ID.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Performs validation of the command.
+    /// </summary>
+    /// <returns>A validation result</returns>
+    public ValidationResultDetail Validate()
+    {
+        var validator = new CancelSaleCommandValidator();
+        var result = validator.Validate(this);
+        return new ValidationResultDetail
+        {
+            IsValid = result.IsValid,
+            Errors = result.Errors.Select(o => (ValidationErrorDetail)o)
+        };
+    }
+}

--- a/template/backend/src/Ambev.DeveloperEvaluation.Application/Sales/CancelSale/CancelSaleCommandValidator.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.Application/Sales/CancelSale/CancelSaleCommandValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.CancelSale;
+
+/// <summary>
+/// Validator for CancelSaleCommand.
+/// </summary>
+public class CancelSaleCommandValidator : AbstractValidator<CancelSaleCommand>
+{
+    /// <summary>
+    /// Initializes a new instance of the CancelSaleCommandValidator class.
+    /// </summary>
+    public CancelSaleCommandValidator()
+    {
+        RuleFor(command => command.Id)
+            .NotEmpty()
+            .WithMessage("Sale ID is required");
+    }
+}

--- a/template/backend/src/Ambev.DeveloperEvaluation.Application/Sales/CancelSale/CancelSaleHandler.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.Application/Sales/CancelSale/CancelSaleHandler.cs
@@ -1,0 +1,48 @@
+using AutoMapper;
+using MediatR;
+using FluentValidation;
+using Ambev.DeveloperEvaluation.Domain.Services;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.CancelSale;
+
+/// <summary>
+/// Handler for processing CancelSaleCommand requests.
+/// </summary>
+public class CancelSaleHandler : IRequestHandler<CancelSaleCommand, CancelSaleResult>
+{
+    private readonly ISaleService _saleService;
+    private readonly IMapper _mapper;
+
+    /// <summary>
+    /// Initializes a new instance of CancelSaleHandler.
+    /// </summary>
+    /// <param name="saleService">The sale service</param>
+    /// <param name="mapper">The AutoMapper instance</param>
+    public CancelSaleHandler(ISaleService saleService, IMapper mapper)
+    {
+        _saleService = saleService;
+        _mapper = mapper;
+    }
+
+    /// <summary>
+    /// Handles the CancelSaleCommand request.
+    /// </summary>
+    /// <param name="command">The CancelSale command</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The cancelled sale details</returns>
+    public async Task<CancelSaleResult> Handle(CancelSaleCommand command, CancellationToken cancellationToken)
+    {
+        var validator = new CancelSaleCommandValidator();
+        var validationResult = await validator.ValidateAsync(command, cancellationToken);
+
+        if (!validationResult.IsValid)
+            throw new ValidationException(validationResult.Errors);
+
+        // Cancel the sale using the domain service
+        var sale = await _saleService.CancelSaleAsync(command.Id, cancellationToken);
+
+        // Map to result
+        var result = _mapper.Map<CancelSaleResult>(sale);
+        return result;
+    }
+}

--- a/template/backend/src/Ambev.DeveloperEvaluation.Application/Sales/CancelSale/CancelSaleProfile.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.Application/Sales/CancelSale/CancelSaleProfile.cs
@@ -1,0 +1,20 @@
+using AutoMapper;
+using Ambev.DeveloperEvaluation.Domain.Entities;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.CancelSale;
+
+/// <summary>
+/// AutoMapper profile for CancelSale operations.
+/// </summary>
+public class CancelSaleProfile : Profile
+{
+    /// <summary>
+    /// Initializes a new instance of the CancelSaleProfile class.
+    /// </summary>
+    public CancelSaleProfile()
+    {
+        CreateMap<Sale, CancelSaleResult>()
+            .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.Status.ToString()))
+            .ForMember(dest => dest.CancelledAt, opt => opt.MapFrom(src => src.UpdatedAt));
+    }
+}

--- a/template/backend/src/Ambev.DeveloperEvaluation.Application/Sales/CancelSale/CancelSaleResult.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.Application/Sales/CancelSale/CancelSaleResult.cs
@@ -1,0 +1,27 @@
+namespace Ambev.DeveloperEvaluation.Application.Sales.CancelSale;
+
+/// <summary>
+/// Result for CancelSaleCommand.
+/// </summary>
+public class CancelSaleResult
+{
+    /// <summary>
+    /// Gets or sets the sale ID.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the sale number.
+    /// </summary>
+    public string SaleNumber { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the sale status.
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the cancellation date.
+    /// </summary>
+    public DateTime? CancelledAt { get; set; }
+}

--- a/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/CancelSale/CancelSaleProfile.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/CancelSale/CancelSaleProfile.cs
@@ -1,0 +1,20 @@
+using AutoMapper;
+using Ambev.DeveloperEvaluation.Application.Sales.CancelSale;
+
+namespace Ambev.DeveloperEvaluation.WebApi.Features.Sales.CancelSale;
+
+/// <summary>
+/// AutoMapper profile for CancelSale operations in WebApi.
+/// </summary>
+public class CancelSaleProfile : Profile
+{
+    /// <summary>
+    /// Initializes a new instance of the CancelSaleProfile class.
+    /// </summary>
+    public CancelSaleProfile()
+    {
+        CreateMap<CancelSaleRequest, CancelSaleCommand>()
+            .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id));
+        CreateMap<CancelSaleResult, CancelSaleResponse>();
+    }
+}

--- a/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/CancelSale/CancelSaleRequest.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/CancelSale/CancelSaleRequest.cs
@@ -1,0 +1,12 @@
+namespace Ambev.DeveloperEvaluation.WebApi.Features.Sales.CancelSale;
+
+/// <summary>
+/// Request model for cancelling a sale.
+/// </summary>
+public class CancelSaleRequest
+{
+    /// <summary>
+    /// Gets or sets the sale ID.
+    /// </summary>
+    public Guid Id { get; set; }
+}

--- a/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/CancelSale/CancelSaleRequestValidator.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/CancelSale/CancelSaleRequestValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+
+namespace Ambev.DeveloperEvaluation.WebApi.Features.Sales.CancelSale;
+
+/// <summary>
+/// Validator for CancelSaleRequest.
+/// </summary>
+public class CancelSaleRequestValidator : AbstractValidator<CancelSaleRequest>
+{
+    /// <summary>
+    /// Initializes a new instance of the CancelSaleRequestValidator class.
+    /// </summary>
+    public CancelSaleRequestValidator()
+    {
+        RuleFor(request => request.Id)
+            .NotEmpty()
+            .WithMessage("Sale ID is required");
+    }
+}

--- a/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/CancelSale/CancelSaleResponse.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/CancelSale/CancelSaleResponse.cs
@@ -1,0 +1,27 @@
+namespace Ambev.DeveloperEvaluation.WebApi.Features.Sales.CancelSale;
+
+/// <summary>
+/// Response model for sale cancellation.
+/// </summary>
+public class CancelSaleResponse
+{
+    /// <summary>
+    /// Gets or sets the sale ID.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the sale number.
+    /// </summary>
+    public string SaleNumber { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the sale status.
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the cancellation date.
+    /// </summary>
+    public DateTime? CancelledAt { get; set; }
+}


### PR DESCRIPTION
This commit introduces the `CancelSaleCommand`, its validator, and handler to facilitate sale cancellations in the application. It implements the `IRequest` interface from MediatR for CQRS support. The command is validated to ensure the sale ID is provided, and the handler interacts with the `ISaleService` to perform the cancellation, mapping results to a `CancelSaleResult`. AutoMapper profiles are added for mapping between request and command objects, as well as between command results and response models. The `CancelSaleRequest` and `CancelSaleResponse` classes are defined to structure incoming requests and outgoing responses, respectively, enhancing the overall functionality for handling sale cancellations.