### PR TITLE
fixMap

### DIFF
--- a/template/backend/src/Ambev.DeveloperEvaluation.Application/Sales/CancelSale/CancelSaleCommand.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.Application/Sales/CancelSale/CancelSaleCommand.cs
@@ -14,6 +14,20 @@ public class CancelSaleCommand : IRequest<CancelSaleResult>
     public Guid Id { get; set; }
 
     /// <summary>
+    /// Initializes a new instance of the CancelSaleCommand class.
+    /// </summary>
+    public CancelSaleCommand() { }
+
+    /// <summary>
+    /// Initializes a new instance of the CancelSaleCommand class with an ID.
+    /// </summary>
+    /// <param name="id">The sale ID</param>
+    public CancelSaleCommand(Guid id)
+    {
+        Id = id;
+    }
+
+    /// <summary>
     /// Performs validation of the command.
     /// </summary>
     /// <returns>A validation result</returns>

--- a/template/backend/src/Ambev.DeveloperEvaluation.Application/Sales/GetSale/GetSaleCommand.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.Application/Sales/GetSale/GetSaleCommand.cs
@@ -14,6 +14,20 @@ public class GetSaleCommand : IRequest<GetSaleResult>
     public Guid Id { get; set; }
 
     /// <summary>
+    /// Initializes a new instance of the GetSaleCommand class.
+    /// </summary>
+    public GetSaleCommand() { }
+
+    /// <summary>
+    /// Initializes a new instance of the GetSaleCommand class with an ID.
+    /// </summary>
+    /// <param name="id">The sale ID</param>
+    public GetSaleCommand(Guid id)
+    {
+        Id = id;
+    }
+
+    /// <summary>
     /// Performs validation of the command.
     /// </summary>
     /// <returns>A validation result</returns>

--- a/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Common/BaseController.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Common/BaseController.cs
@@ -14,7 +14,7 @@ public class BaseController : ControllerBase
         User.FindFirst(ClaimTypes.Email)?.Value ?? throw new NullReferenceException();
 
     protected IActionResult Ok<T>(T data) =>
-            base.Ok(new ApiResponseWithData<T> { Data = data, Success = true });
+            base.Ok(data); // Retorna diretamente os dados sem wrapper extra
 
     protected IActionResult Created<T>(string routeName, object routeValues, T data) =>
         base.CreatedAtRoute(routeName, routeValues, new ApiResponseWithData<T> { Data = data, Success = true });

--- a/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/CancelSale/CancelSaleProfile.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/CancelSale/CancelSaleProfile.cs
@@ -13,6 +13,8 @@ public class CancelSaleProfile : Profile
     /// </summary>
     public CancelSaleProfile()
     {
+        CreateMap<Guid, CancelSaleCommand>()
+            .ConstructUsing(id => new CancelSaleCommand(id));
         CreateMap<CancelSaleRequest, CancelSaleCommand>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id));
         CreateMap<CancelSaleResult, CancelSaleResponse>();

--- a/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/GetSale/GetSaleProfile.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/GetSale/GetSaleProfile.cs
@@ -13,6 +13,8 @@ public class GetSaleProfile : Profile
     /// </summary>
     public GetSaleProfile()
     {
+        CreateMap<Guid, GetSaleCommand>()
+            .ConstructUsing(id => new GetSaleCommand(id));
         CreateMap<GetSaleRequest, GetSaleCommand>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id));
         CreateMap<GetSaleResult, GetSaleResponse>();

--- a/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/SalesController.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/SalesController.cs
@@ -84,7 +84,7 @@ public class SalesController : BaseController
         var command = _mapper.Map<GetSaleCommand>(request.Id);
         var response = await _mediator.Send(command, cancellationToken);
 
-        return Ok(new ApiResponseWithData<GetSaleResponse>
+        return base.Ok(new ApiResponseWithData<GetSaleResponse>
         {
             Success = true,
             Message = "Sale retrieved successfully",
@@ -142,7 +142,7 @@ public class SalesController : BaseController
         var command = _mapper.Map<CancelSaleCommand>(request.Id);
         var response = await _mediator.Send(command, cancellationToken);
 
-        return Ok(new ApiResponseWithData<CancelSaleResponse>
+        return base.Ok(new ApiResponseWithData<CancelSaleResponse>
         {
             Success = true,
             Message = "Sale cancelled successfully",


### PR DESCRIPTION
…and>` e `CreateMap<Guid, CancelSaleCommand>` nos perfis para resolver erros de mapeamento.

2. **Construtores**: Criei construtores `GetSaleCommand(Guid id)` e `CancelSaleCommand(Guid id)` nas commands para permitir o mapeamento do AutoMapper.

3. **BaseController**: Modifiquei o método `Ok<T>()` para retornar `base.Ok(data)` em vez de `ApiResponseWithData<T>`, eliminando o duplo aninhamento na resposta da API.

4. **SalesController**: Atualizei todos os métodos (`GetSales`, `GetSale`, `CancelSale`) para usar `base.Ok()` em vez de `Ok()`, garantindo a estrutura correta da resposta.